### PR TITLE
fixes slow sudo (adds new hostname to hosts file)

### DIFF
--- a/genie/Program.cs
+++ b/genie/Program.cs
@@ -141,6 +141,14 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
                 Environment.Exit (p.ExitCode);
             }
 
+            p = Process.Start ("/bin/sh", "-c \"/bin/echo 127.0.0.1 `hostname`-wsl >> /etc/hosts\"");
+            p.WaitForExit();
+            if (p.ExitCode != 0)
+            {
+                Console.WriteLine ($"genie: initializing bottle failed; adding new hostname to hosts returned {p.ExitCode}.");
+                Environment.Exit (p.ExitCode);
+            }
+
             // Run systemd in a container.
             p = Process.Start ("/usr/sbin/daemonize", "/usr/bin/unshare -fp --mount-proc /lib/systemd/systemd");
             p.WaitForExit();


### PR DESCRIPTION
And here's the new one with the unintentional commits removed.

From original pull request:
If sudo can not find the hostname in /etc/hosts, it will delay several seconds before executing. This commit adds the new hostname to /etc/hosts as part of the startup sequence.