### PR TITLE
change -s and -c to both use su, fixes arkane-systems/genie#13

### DIFF
--- a/genie/Program.cs
+++ b/genie/Program.cs
@@ -183,7 +183,7 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
             if (verbose)
                 Console.WriteLine ($"genie: running command '{commandLine}'");
 
-            var p = Process.Start ("/usr/bin/nsenter", $"-t {systemdPid} -S {realUserId} -G {realGroupId}  --wd=\"{Environment.CurrentDirectory}\" -m -p {commandLine}");
+            var p = Process.Start ("/usr/bin/nsenter", $"-t {systemdPid} --wd=\"{Environment.CurrentDirectory}\" -m -p su {realUserName} -c {commandLine}");
             p.WaitForExit();
 
             if (p.ExitCode != 0)
@@ -199,7 +199,7 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
             if (verbose)
                 Console.WriteLine ("genie: starting shell");
 
-            var p = Process.Start ("/usr/bin/nsenter", $"-t {systemdPid} -m -p /bin/login -f {realUserName}");
+            var p = Process.Start ("/usr/bin/nsenter", $"-t {systemdPid} --wd=\"{Environment.CurrentDirectory}\" -m -p su {realUserName}");
             p.WaitForExit();
 
             if (p.ExitCode != 0)

--- a/genie/Program.cs
+++ b/genie/Program.cs
@@ -183,7 +183,7 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
             if (verbose)
                 Console.WriteLine ($"genie: running command '{commandLine}'");
 
-            var p = Process.Start ("/usr/bin/nsenter", $"-t {systemdPid} --wd=\"{Environment.CurrentDirectory}\" -m -p su {realUserName} -c {commandLine}");
+            var p = Process.Start ("/usr/bin/nsenter", $"-t {systemdPid} --wd=\"{Environment.CurrentDirectory}\" -m -p su {realUserName} -c \"{commandLine}\"");
             p.WaitForExit();
 
             if (p.ExitCode != 0)


### PR DESCRIPTION
After a bit of experimenting I found that su opens a systemd user session without running a login shell. This also means that running genie -s now keeps the working directory.