### PR TITLE
genie worked with Fedora Remix for WSL.

### DIFF
--- a/fedora-build
+++ b/fedora-build
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+PKGNAME=genie-systemd
+
+# Enable dotnet repository setting
+sudo dnf copr enable @dotnet-sig/dotnet -y
+
+# Install hostess
+if [ ! -e /usr/bin/hostess ]; then
+  sudo curl -o /usr/bin/hostess -LO https://github.com/cbednarski/hostess/releases/download/v0.3.0/hostess_linux_amd64
+  sudo chmod 755 /usr/bin/hostess
+fi
+
+# Install dotnet and dependent packages
+sudo dnf install daemonize dotnet-runtime-2.2 dotnet-host-fxr-2.2 dotnet-sdk-2.2
+
+# Build genie
+cd genie
+dotnet publish -r linux-x64 --self-contained false
+cd ..
+
+# Install genie
+sudo install -Dm 4755 -o root "genie/bin/Debug/netcoreapp2.2/linux-x64/publish/genie" -t "/usr/bin"
+sudo install -Dm 644 -o root "genie/bin/Debug/netcoreapp2.2/linux-x64/publish/genie.dll" -t "/usr/bin"
+sudo install -Dm 744 -o root "genie/bin/Debug/netcoreapp2.2/linux-x64/publish/Linux.ProcessManager.dll" -t "/usr/bin"
+sudo install -Dm 744 -o root "genie/bin/Debug/netcoreapp2.2/linux-x64/publish/System.CommandLine.dll" -t "/usr/bin"
+sudo install -Dm 744 -o root "genie/bin/Debug/netcoreapp2.2/linux-x64/publish/Tmds.LibC.dll" -t "/usr/bin"
+sudo install -Dm 644 -o root "genie/bin/Debug/netcoreapp2.2/linux-x64/publish/genie.runtimeconfig.json" -t "/usr/bin"
+sudo install -Dm 755 -o root "systemd-genie/lib/genie/dumpwslenv.sh" -t "/usr/lib/genie/"
+sudo install -Dm 755 -o root "systemd-genie/lib/genie/readwslenv.sh" -t "/usr/lib/genie/"
+sudo install -Dm 755 -o root "systemd-genie/lib/genie/runinwsl.sh" -t "/usr/lib/genie/"
+sudo install -Dm 755 -o root "systemd-genie/lib/systemd/system-environment-generators/10-genie-envar.sh" -t "/usr/lib/systemd/system-environment-generators"
+sudo install -Dm 644 "LICENSE" "/usr/share/licenses/${PKGNAME}/LICENSE"

--- a/genie/Program.cs
+++ b/genie/Program.cs
@@ -72,19 +72,19 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
             var rootCommand = new RootCommand();
             rootCommand.Description = "Handles transitions to the \"bottle\" namespace for systemd under WSL.";
             rootCommand.AddOption (optVerbose);
-            rootCommand.Handler = CommandHandler.Create<bool>(RootHandler);
+            rootCommand.Handler = CommandHandler.Create<bool>((Func<bool, int>)RootHandler);
 
             var cmdInitialize = new Command ("--initialize");
             cmdInitialize.AddAlias ("-i");
             cmdInitialize.Description = "Initialize the bottle (if necessary) only.";
-            cmdInitialize.Handler = CommandHandler.Create<bool>(InitializeHandler);
+            cmdInitialize.Handler = CommandHandler.Create<bool>((Func<bool, int>)InitializeHandler);
 
             rootCommand.Add (cmdInitialize);
 
             var cmdShell = new Command ("--shell");
             cmdShell.AddAlias ("-s");
             cmdShell.Description = "Initialize the bottle (if necessary), and run a shell in it.";
-            cmdShell.Handler = CommandHandler.Create<bool>(ShellHandler);
+            cmdShell.Handler = CommandHandler.Create<bool>((Func<bool, int>)ShellHandler);
 
             rootCommand.Add (cmdShell);
 
@@ -96,7 +96,7 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
             cmdExec.AddAlias ("-c");
             cmdExec.Argument = argCmdLine;
             cmdExec.Description = "Initialize the bottle (if necessary), and run the specified command in it.";
-            cmdExec.Handler = CommandHandler.Create<bool, List<string>>(ExecHandler);
+            cmdExec.Handler = CommandHandler.Create<bool, List<string>>((Func<bool, List<string>, int>)ExecHandler);
 
             rootCommand.Add (cmdExec);
 


### PR DESCRIPTION
Since error CS0121 occurred in the build, it was corrected.
> $ cd genie/genie
> $ dotnet publish -r linux-x64 --self-contained false
> Program.cs(75,50): error CS0121: The call is ambiguous between the following methods or properties: 'CommandHandler.Create<T>(Func<T, int>)' and 'CommandHandler.Create<T>(Func<T, Task<int>>)' [/mnt/c/Users/tomoyan/genie/genie/genie.csproj]
> Program.cs(80,52): error CS0121: The call is ambiguous between the following methods or properties: 'CommandHandler.Create<T>(Func<T, int>)' and 'CommandHandler.Create<T>(Func<T, Task<int>>)' [/mnt/c/Users/tomoyan/genie/genie/genie.csproj]
> Program.cs(87,47): error CS0121: The call is ambiguous between the following methods or properties: 'CommandHandler.Create<T>(Func<T, int>)' and 'CommandHandler.Create<T>(Func<T, Task<int>>)' [/mnt/c/Users/tomoyan/genie/genie/genie.csproj]
> Program.cs(99,46): error CS0121: The call is ambiguous between the following methods or properties: 'CommandHandler.Create<T1, T2>(Func<T1, T2, int>)' and 'CommandHandler.Create<T1, T2>(Func<T1, T2, Task<int>>)' [/mnt/c/Users/tomoyan/genie/genie/genie.csproj]

First of all, I created a script that can be installed on Fedora Remix.
> $ cd ~
> $ git clone <genie-systemd repository>
> $ cd genie
> $ ./fedora-build

If you build with the 9p file system, the executable will be corrupted.
When building with /mnt/c, the following error occurred and it did not work.
> $ genie/bin/Debug/netcoreapp2.2/linux-x64/publish/genie
> This executable is not bound to a managed DLL to execute. The binding value is: 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2'
> A fatal error was encountered. This executable was not bound to load a managed DLL.

You can avoid this by doing a cd ~ and then building with git clone.

This works well.
> bash
> $ genie -s

But for some reason this doesn't work.
> wsl genie -s
> A fatal error occurred, the required library libhostfxr.so could not be found.
> If this is a self-contained application, that library should exist in [/usr/bin/].
> If this is a framework-dependent application, install the runtime in the default location [/usr/share/dotnet] or use the DOTNET_ROOT environment variable to specify the runtime location.

https://www.tomoyan.net/windows/wsl#genie-systemd_%E3%81%AE_fork