### PR TITLE
Deviations for Ubuntu 20.04

### DIFF
--- a/ubuntu/deviated-preverts.conf
+++ b/ubuntu/deviated-preverts.conf
@@ -1,3 +1,6 @@
 {
-  "daemonize": "/usr/bin/daemonize"
+  "daemonize": "/usr/bin/daemonize",
+  "mount": "/bin/mount",
+  "runuser": "/sbin/runuser",
+  "systemd": "/bin/systemd"
 }


### PR DESCRIPTION
Upgrading from systemd-genie 1.23 to sytemd-genie 1.24 on Ubuntu Focal failed to start it until I applied this patch to `/usr/lib/genie/deviated-preverts.conf`.