### PR TITLE
Arch: update PKGBUILD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ genie.spec
 *.deb
 *.tar
 *.tar.gz
+arch/pkg
 genie/debian/systemd-genie
 genie/debian/.debhelper
 genie/debian/systemd-genie*

--- a/arch/PKGBUILD
+++ b/arch/PKGBUILD
@@ -2,8 +2,7 @@
 # Contributor: facekapow, rayfalling, Ducksoft
 
 pkgname=genie-systemd
-_pkgname=genie
-pkgver=1.29
+pkgver=1.32
 pkgrel=1
 pkgdesc="A quick way into a systemd \"bottle\" for WSL"
 arch=('x86_64')
@@ -12,31 +11,37 @@ depends=('daemonize' 'dotnet-runtime>=5.0' 'dotnet-host>=5.0' 'inetutils')
 makedepends=('dotnet-sdk>=5.0')
 conflicts=('genie-systemd')
 provides=('genie-systemd')
-source=('git+https://github.com/arkane-systems/genie.git')
-sha256sums=('SKIP')
 options=(!strip)
 
-prepare() {
-  	cd "${srcdir}/$_pkgname"
+pkgver() {
+  cd ../../genie
+  grep VersionPrefix genie/genie.csproj | sed 's/.*<VersionPrefix>\(.*\)<\/VersionPrefix>/\1/' | tr -d '\r\n'
 }
 
 build() {
-  	export DOTNET_CLI_TELEMETRY_OPTOUT=1
-  	export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
-  	cd "$srcdir/$_pkgname/$_pkgname"
-  	export DESTDIR=$pkgdir
-  	ls -alh
-  	make build
+  cd ../../genie/
+  export DOTNET_CLI_TELEMETRY_OPTOUT=1
+  export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
+  make build
 }
 
 package() {
-  	cd "$srcdir/$_pkgname/$_pkgname"
-  	make install
-	mkdir -p ${pkgdir}/usr/bin
-	chmod +x ${pkgdir}/usr/libexec/genie
-	ln -s /usr/libexec/genie/genie ${pkgdir}/usr/bin/genie
-	cp "$srcdir/$_pkgname/$_pkgname/docs/genie.8" /tmp/genie.8
-	gzip -9 /tmp/genie.8
-	install -Dm 0644 -o root /tmp/genie.8.gz -t "${pkgdir}/usr/share/man/man8"
-	rm /tmp/genie.8.gz
+  cd ../../genie/
+  make DESTDIR="$pkgdir/" install
+
+  # genie symlink
+  mkdir -p ${pkgdir}/usr/bin
+  ln -s /usr/libexec/genie/genie ${pkgdir}/usr/bin/genie
+
+  # 10-genie-envar.sh symlinks
+  mkdir -p ${pkgdir}/usr/lib/systemd/user-environment-generators
+  mkdir -p ${pkgdir}/usr/lib/systemd/system-environment-generators
+  ln -s /usr/libexec/genie/10-genie-envar.sh ${pkgdir}/usr/lib/systemd/user-environment-generators/10-genie-envar.sh
+  ln -s /usr/libexec/genie/10-genie-envar.sh ${pkgdir}/usr/lib/systemd/system-environment-generators/10-genie-envar.sh
+
+  # man page
+  cp docs/genie.8 /tmp/genie.8
+  gzip -9 /tmp/genie.8
+  install -Dm 0644 -o root /tmp/genie.8.gz -t "${pkgdir}/usr/share/man/man8"
+  rm /tmp/genie.8.gz
 }

--- a/arch/genie
+++ b/arch/genie
@@ -1,1 +1,0 @@
-../genie/genie


### PR DESCRIPTION
While I'm no PKGBUILD expert (in fact this was my first time doing any major edit to an AUR package), I believe I have updated it for compatibility with 1.32 and improved a few aspects. I successfully built and installed the package on my system, where it works fine.

- Add support for 10-genie-envar.sh and related symlinks
- Use `make DESTDIR=...` instead of copying files manually as suggested by the Arch Wiki, thus reusing the Makefile as much as possible
- Avoid cloning the repository: a PKGBUILD can skip the sources array altogether and just cd to the correct directory, which seems like the best option when we're already in the git repo
- Remove the arch/genie symlink as it's not needed
- Determine pkgver automatically: i'm reading VersionPrefix from genie/genie.csproj to set the package version automatically when makepkg builds it
- Add arch/pkg (the build directory) to .gitignore
- Remove arch/not-yet-updated-to-1.30-file-changes

I hope it's helpful!