### PR TITLE
Fix Fedora Makefile and RPM spec

### DIFF
--- a/package/fedora/Makefile
+++ b/package/fedora/Makefile
@@ -6,11 +6,12 @@
 # Default target: package.
 #
 
+genie_version:=$(shell rpmspec -q --qf %{Version} --srpm genie.spec)
+
 package:
 	# Packaging for Fedora.
 	rpmdev-setuptree
-	export VERSION=`rpmspec  -q --qf %{Version} --srpm genie.spec`
-	tar zcvf ~/rpmbuild/SOURCES/genie-${VERSION}.tar.gz * --dereference --transform='s/^/genie-${VERSION}\//'
+	tar zcvf ~/rpmbuild/SOURCES/genie-${genie_version}.tar.gz * --dereference --transform='s/^/genie-${genie_version}\//'
 	rpmbuild -ba -v genie.spec
 	mkdir -p ../../out/fedora
 	mv ~/rpmbuild/RPMS/x86_64/genie* ../../out/fedora

--- a/package/fedora/genie.spec
+++ b/package/fedora/genie.spec
@@ -35,19 +35,19 @@ make -C binsrc
 pwd
 install -d -p %{buildroot}%{_libexecdir}/%{name}
 install -d -p %{buildroot}%{_sysconfdir}
+install -d -p %{buildroot}%{_exec_prefix}/lib/systemd/system-environment-generators
+install -d -p %{buildroot}%{_bindir}
 install -m 4755 -vp binsrc/genie/bin/Release/net5.0/linux-x64/publish/genie %{buildroot}%{_libexecdir}/%{name}
 install -m 0755 -vp binsrc/runinwsl/bin/Release/net5.0/linux-x64/publish/runinwsl %{buildroot}%{_libexecdir}/%{name}
 install -m 0755 -vp othersrc/scripts/10-genie-envar.sh %{buildroot}%{_libexecdir}/%{name}
 install -m 0755 -vp othersrc/etc/genie.ini %{buildroot}%{_sysconfdir}/
-
-%post
-ln -s %{_libexecdir}/%{name}/%{name} %{_bindir}/%{name}
-ln -s %{_libexecdir}/%{name}/10-genie-envar.sh %{_exec_prefix}/lib/systemd/system-environment-generators/
+ln -sf %{_libexecdir}/%{name}/%{name} %{buildroot}%{_bindir}/%{name}
+ln -sf %{_libexecdir}/%{name}/10-genie-envar.sh %{buildroot}%{_exec_prefix}/lib/systemd/system-environment-generators/
 
 %postun
 rm -rf %{_libexecdir}/%{name}
 rm -f %{_bindir}/%{name}
-rm -f %{_exec_prefix}/lib/systemd/system-environment-generators/10-envar.sh
+rm -f %{_exec_prefix}/lib/systemd/system-environment-generators/10-genie-envar.sh
 
 %clean
 rm -rf %{buildroot}
@@ -55,6 +55,8 @@ rm -rf %{buildroot}
 %files
 %{_libexecdir}/%{name}/*
 %config %{_sysconfdir}/genie.ini
+%{_bindir}/%{name}
+%{_exec_prefix}/lib/systemd/system-environment-generators/10-genie-envar.sh
 
 %changelog
 * Sun Mar 14 2021 Alistair Young <avatar@arkane-systems.net> 1.37-1


### PR DESCRIPTION
- Replaced transient export of VERSION variable to a Make variable in package-fedora Makefile
- Corrected typo of "10-envar.sh" to "10-genie-envar.sh" in "postun" section of genie.spec
- Changed symlink creation in "post" section to instead install the symlinks as part of the package