### PR TITLE
Configurable hostname suffix (in /etc/genie.ini)

### DIFF
--- a/binsrc/genie/Configuration.cs
+++ b/binsrc/genie/Configuration.cs
@@ -46,6 +46,9 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
         // True to update the host name with the "-wsl" suffix, false otherwise.
         internal bool UpdateHostname => this.Configuration.GetValue<bool> ("genie:update-hostname", true);
 
+        // True to update the host name with the "-wsl" suffix, false otherwise.
+        internal string HostnameSuffix => this.Configuration.GetValue<string> ("genie:update-hostname-suffix", "-wsl");
+
         // Path to the local binary for unshare(1).
         internal string PathToUnshare => this.Configuration.GetValue<string> ("genie:unshare", "/usr/bin/unshare");
 

--- a/binsrc/genie/Helpers.cs
+++ b/binsrc/genie/Helpers.cs
@@ -91,7 +91,7 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
         #region Hostname management
 
         // Add the "-wsl" suffix to the system hostname, and update the hosts file accordingly.
-        internal static void UpdateHostname (bool verbose)
+        internal static void UpdateHostname (string HostnameSuffix, bool verbose)
         {
             // Generate new hostname.
             if (verbose)
@@ -103,7 +103,7 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
                 Console.WriteLine ($"genie: external hostname is {externalHost}");
 
             // Make new hostname.
-            string internalHost = $"{externalHost.Substring(0, (externalHost.Length <= 60 ? externalHost.Length : 60))}-wsl";
+            string internalHost = $"{externalHost.Substring(0, (externalHost.Length <= 60 ? externalHost.Length : 60))}{HostnameSuffix}";
 
             File.WriteAllLines ("/run/hostname-wsl", new string[] {
                 internalHost

--- a/binsrc/genie/Program.cs
+++ b/binsrc/genie/Program.cs
@@ -405,7 +405,7 @@ namespace ArkaneSystems.WindowsSubsystemForLinux.Genie
             // it automatically in genie an option, enable/disable in genie.ini. Defaults to on
             // for backwards compatibility.
             if (Config.UpdateHostname)
-                Helpers.UpdateHostname (verbose);
+                Helpers.UpdateHostname (Config.HostnameSuffix, verbose);
 
             // If configured to, create the resolv.conf symlink.
             if (Config.ResolvedStub)

--- a/othersrc/etc/genie.ini
+++ b/othersrc/etc/genie.ini
@@ -2,6 +2,7 @@
 secure-path=/lib/systemd:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 unshare=/usr/bin/unshare
 update-hostname=true
+update-hostname-suffix="-wsl"
 clone-path=false
 clone-env=WSL_DISTRO_NAME,WSL_INTEROP,WSLENV,DISPLAY,WAYLAND_DISPLAY,PULSE_SERVER
 systemd-timeout=240


### PR DESCRIPTION
The goal of this PR is to allow people who use non-preview wsl have multiple distros configured to have their very own hostnames. 
This allows distros to be addressable on network by unique hostnames.
![image](https://user-images.githubusercontent.com/7080404/131165667-9525d356-160c-443d-817b-675cf7a092c6.png)
![image](https://user-images.githubusercontent.com/7080404/131165680-4556ce5b-5a08-408b-a6c2-e72243589c5a.png)
![image](https://user-images.githubusercontent.com/7080404/131166429-5bfffdb0-1e91-497c-be43-8c92e3ae22dc.png)
![image](https://user-images.githubusercontent.com/7080404/131166440-ed7b3048-777d-4d21-b8c7-c8042e95f6e3.png)


Thus this PR makes the hostname suffix ("-wsl" by default) configurable in /etc/genie.ini
![image](https://user-images.githubusercontent.com/7080404/131166896-1d579388-e846-43e6-ab22-290319be925e.png)
![image](https://user-images.githubusercontent.com/7080404/131166930-901b306f-5a7d-4ed5-81cb-0b64d9677402.png)



