### PR TITLE
Accommodate custom rpmbuild locations

### DIFF
--- a/package/fedora/Makefile
+++ b/package/fedora/Makefile
@@ -8,14 +8,17 @@
 
 genie_version:=$(shell rpmspec -q --qf %{Version} --srpm genie.spec)
 
+sourcedir=$(shell rpm --eval '%{_sourcedir}')
+rpmdir=$(shell rpm --eval '%{_rpmdir}')
+
 package:
 	# Packaging for Fedora.
 	rpmdev-setuptree
-	tar zcvf ~/rpmbuild/SOURCES/genie-${genie_version}.tar.gz * --dereference --transform='s/^/genie-${genie_version}\//'
+	tar zcvf $(sourcedir)/genie-${genie_version}.tar.gz * --dereference --transform='s/^/genie-${genie_version}\//'
 	rpmbuild -ba -v genie.spec
 	mkdir -p ../../out/fedora
-	mv ~/rpmbuild/RPMS/x86_64/genie* ../../out/fedora
+	mv $(rpmdir)/x86_64/genie* ../../out/fedora
 
 clean:
 	# Clean up temporary tree.
-	rm -rf ~/rpmbuild
+	rpmdev-wipetree


### PR DESCRIPTION
It is possible to have the rpmbuild directory elsewhere with a simple

    $ cat > ~/.rpmmacros <<EOF
    %_topdir %(echo "$HOME")/work/rpmbuild
    EOF

Luckily RPM offers tools to figure out the locations.