### PR TITLE
Bump python_hosts dependency

### DIFF
--- a/binsrc/genie/requirements.txt
+++ b/binsrc/genie/requirements.txt
@@ -1,3 +1,3 @@
 nsenter>=0.2
 psutil>=5.9.0
-python_hosts>=0.3.2
+python_hosts>=1.0.1


### PR DESCRIPTION
we require find_all_matching(), which was added in v1.0.1