### PR TITLE
force gzip to overwrite temp manpage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,7 @@ internal-supplement:
 
  	# this bit would ordinarily be handed by debuild, etc.
 	cp "othersrc/docs/genie.8" /tmp/genie.8
-	gzip -9 "/tmp/genie.8"
+	gzip -f9 "/tmp/genie.8"
 	install -Dm 0644 -o root "/tmp/genie.8.gz" -t "$(MAN8DIR)"
 
 internal-tar:


### PR DESCRIPTION
Doing a cleanBuild doesn't seem to delete the previously gzipped manpage in `/tmp`.
I added the `-f` flag to overwrite anyway so gzip won't prompt the user to overwrite. 