### PR TITLE
Add missing dependency for Arch Linux.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,7 +10,7 @@ pkgdesc="A quick way into a systemd \"bottle\" for WSL"
 arch=('x86_64')
 url="https://github.com/arkane-systems/genie"
 license=('Unlicense')
-depends=('daemonize' 'python>=3.7' 'python-psutil' 'systemd>=232.25')
+depends=('daemonize' 'python>=3.7' 'python-psutil' 'systemd>=232.25' 'inetutils')
 makedepends=('git' 'python-pip')
 options=(!strip)
 source=("git+https://github.com/arkane-systems/genie.git")


### PR DESCRIPTION
`genie -u` calls `hostname`, which is not installed by default, and is
provided by `inettools`.