### PR TITLE
Add aarch64 support, GitHub Actions for Fedora RPMs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,3 +30,31 @@ jobs:
       with:
         name: debpkg
         path: out/debian/*
+  build-fedora:
+    strategy:
+      matrix:
+        fedora_version: [35, 36, 37]
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:${{ matrix.fedora_version }}
+    steps:
+    - name: dnf update
+      run: sudo dnf update -y
+    - name: Install Packagers & Cross-Compiler
+      run: |
+        sudo dnf install -y \
+          @development-tools \
+          @rpm-development-tools \
+          python-pip \
+          gcc-aarch64-linux-gnu
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Build RPMs
+      run: |
+        make package-fedora RPMBUILD_TARGET=x86_64
+        make package-fedora RPMBUILD_TARGET=aarch64
+    - name: Upload Results
+      uses: actions/upload-artifact@v3
+      with:
+        name: rpm
+        path: out/fedora/*

--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,11 @@ clean-arch:
 
 package-fedora: genie_version := $(shell rpmspec -q --qf %{Version} --srpm genie.spec)
 
+RPMBUILD_TARGET = $(shell uname --processor)
 package-fedora:
 	rpmdev-setuptree
 	tar zcvf $(shell rpm --eval '%{_sourcedir}')/genie-${genie_version}.tar.gz * --dereference --transform='s/^/genie-${genie_version}\//'
-	fakeroot rpmbuild -ba -v genie.spec
+	fakeroot rpmbuild --target $(RPMBUILD_TARGET) -ba -v genie.spec
 	mkdir -p out/fedora
 	mv $(shell rpm --eval '%{_rpmdir}')/*/genie* out/fedora
 

--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ package-fedora:
 	tar zcvf $(shell rpm --eval '%{_sourcedir}')/genie-${genie_version}.tar.gz * --dereference --transform='s/^/genie-${genie_version}\//'
 	fakeroot rpmbuild -ba -v genie.spec
 	mkdir -p out/fedora
-	mv $(shell rpm --eval '%{_rpmdir}')/x86_64/genie* out/fedora
+	mv $(shell rpm --eval '%{_rpmdir}')/*/genie* out/fedora
 
 clean-fedora:
 	rpmdev-wipetree

--- a/genie.spec
+++ b/genie.spec
@@ -26,8 +26,6 @@ Requires:      systemd-container >= 232.25
 # BuildRequires: git
 BuildRequires: make
 
-ExclusiveArch: x86_64
-
 %description
 A quick way into systemd "bottle" for WSL
 


### PR DESCRIPTION
genie seems to work + build fine on my Fedora 35 WSL2 installation under ARM after modifying the spec file and make target a bit, so the first commit reflects that.

The second commit modifies the package-fedora make target to accept platforms as a make arg, passing that to rpmbuild to create RPMs for Fedora 34-36.

(RPM artifacts can be seen here: https://github.com/mark-ignacio/genie/actions/runs/2542257139)