### PR TITLE
The /tmp/.X11-unix/X0 symlink is not necessary anymore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,9 +151,6 @@ internal-package:
 	# binfmt.d
 	install -Dm 0644 -o root "othersrc/usr-lib/binfmt.d/WSLInterop.conf" -t "$(USRLIBDIR)/binfmt.d"
 
-	# tmpfiles.d
-	install -Dm 0644 -o root "othersrc/usr-lib/tmpfiles.d/wslg.conf" -t "$(USRLIBDIR)/tmpfiles.d"
-
 internal-clean:
 	make -C binsrc clean
 

--- a/genie.spec
+++ b/genie.spec
@@ -42,7 +42,6 @@ install -d -p %{buildroot}%{_sysconfdir}
 install -d -p %{buildroot}%{_exec_prefix}/lib/%{name}
 install -d -p %{buildroot}%{_exec_prefix}/lib/systemd/system-environment-generators
 install -d -p %{buildroot}%{_exec_prefix}/lib/systemd/user-environment-generators
-install -d -p %{buildroot}%{_exec_prefix}/lib/tmpfiles.d
 install -d -p %{buildroot}%{_exec_prefix}/lib/binfmt.d
 install -d -p %{buildroot}%{_bindir}
 install -d -p %{buildroot}%{_unitdir}
@@ -58,7 +57,6 @@ rm -f %{_bindir}/%{name}
 rm -rf %{_exec_prefix}/lib/%{name}/*
 rm -f %{_unitdir}/user-runtime-dir@.service.d/override.conf
 rm -f %{_exec_prefix}/lib/binfmt.d/WSLInterop.conf
-rm -f %{_exec_prefix}/lib/tmpfiles.d/wslg.conf
 rm -f %{_exec_prefix}/lib/systemd/system-environment-generators/80-genie-envar.sh
 rm -f %{_exec_prefix}/lib/systemd/user-environment-generators/80-genie-envar.sh
 rm -f ${_mandir}/man8/genie.8.gz
@@ -74,7 +72,6 @@ rm -rf %{buildroot}
 %config %{_sysconfdir}/genie.ini
 %{_unitdir}/user-runtime-dir@.service.d/override.conf
 %{_exec_prefix}/lib/binfmt.d/WSLInterop.conf
-%{_exec_prefix}/lib/tmpfiles.d/wslg.conf
 %{_exec_prefix}/lib/systemd/system-environment-generators/80-genie-envar.sh
 %{_exec_prefix}/lib/systemd/user-environment-generators/80-genie-envar.sh
 %doc %{_mandir}/man8/genie.8.gz

--- a/othersrc/usr-lib/tmpfiles.d/wslg.conf
+++ b/othersrc/usr-lib/tmpfiles.d/wslg.conf
@@ -1,7 +1,0 @@
-#  This file is part of genie.
-#
-
-# See tmpfiles.d(5) for details
-
-# Create the needed symlink to make WSLg work under genie.
-L+ /tmp/.X11-unix/X0 - - - - /mnt/wslg/.X11-unix/X0


### PR DESCRIPTION
As of today, on a `Microsoft Windows [Version 10.0.22000.795]` I can see
that `/tmp/.X11-unix` is automatically symlinked to
`/mnt/wslg/.X11-unix` which is a directory.

If anything, genie making `/tmp/.X11-unix/X0` a symlink to
`/mnt/wslg/.X11-unix/X0` actually breaks everything since I end up with
`/mnt/wslg/.X11-unix/X0` being a link to itself.
